### PR TITLE
Added the ability to select a hashing class

### DIFF
--- a/src/TestVHashedStringList.dpr
+++ b/src/TestVHashedStringList.dpr
@@ -13,7 +13,8 @@ Please, don't remove this copyright.
 uses
   Forms,
   Unit1 in 'Unit1.pas' {Form1},
-  VHashedStringList in 'VHashedStringList.pas';
+  VHashedStringList in 'VHashedStringList.pas',
+  murmurhash in 'murmurhash.pas';
 
 {$R *.res}
 

--- a/src/Unit1.dfm
+++ b/src/Unit1.dfm
@@ -1,9 +1,9 @@
 object Form1: TForm1
   Left = 1248
   Top = 481
-  Width = 515
-  Height = 352
   Caption = 'TVHashedStringList Test'
+  ClientHeight = 313
+  ClientWidth = 499
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
@@ -163,5 +163,13 @@ object Form1: TForm1
     Height = 21
     TabOrder = 7
     Text = '100'
+  end
+  object CheckBox3: TCheckBox
+    Left = 288
+    Top = 143
+    Width = 97
+    Height = 17
+    Caption = 'MurMur hash'
+    TabOrder = 8
   end
 end

--- a/src/Unit1.pas
+++ b/src/Unit1.pas
@@ -36,13 +36,14 @@ type
     Edit3: TEdit;
     Label9: TLabel;
     Label10: TLabel;
+    CheckBox3: TCheckBox;
     procedure Button1Click(Sender: TObject);
     procedure Label7Click(Sender: TObject);
   private
     { Private declarations }
     procedure Test(nSet, nGet, nDel: Integer;
       bTVHashedStringList, bGetListItems,
-      bAutoUpdateHash: Boolean);
+      bAutoUpdateHash, bMurMurHash: Boolean);
   public
     { Public declarations }
   end;
@@ -52,18 +53,18 @@ var
 
 implementation
 
-uses ShellAPI;
+uses ShellAPI, murmurhash;
 
 {$R *.dfm}
 
 procedure TForm1.Button1Click(Sender: TObject);
 begin
   Test(StrToInt(Edit1.Text), StrToInt(Edit2.Text), StrToInt(Edit3.Text),
-    RadioButton2.Checked, CheckBox1.Checked, CheckBox2.Checked);
+    RadioButton2.Checked, CheckBox1.Checked, CheckBox2.Checked, CheckBox3.Checked);
 end;
 
 procedure TForm1.Test(nSet, nGet, nDel: Integer;
-  bTVHashedStringList, bGetListItems, bAutoUpdateHash: Boolean);
+  bTVHashedStringList, bGetListItems, bAutoUpdateHash, bMurMurHash: Boolean);
 var
   i, j, n: Integer;
   s, t: String;
@@ -77,6 +78,8 @@ begin
   begin
     lst := TVHashedStringList.Create;
     TVHashedStringList(lst).AutoUpdateHash := bAutoUpdateHash;
+    if bMurMurHash then
+      TVHashedStringList(lst).HashClass := TMurMurHash;
   end else
     lst := TStringList.Create;
   dwTick := GetTickCount;

--- a/src/VHashedStringList.pas
+++ b/src/VHashedStringList.pas
@@ -43,6 +43,8 @@ type
     function ValueOf(const Key: String): Integer;
   end;
 
+  TVStringHashClass = class of TVStringHash;
+
   TVHashedStringList = class(TStringList)
   private
     FBucketsSize: Cardinal;
@@ -52,6 +54,7 @@ type
     FNameHashValid: Boolean;
     FOwnsObjects: Boolean;
     FAutoUpdateHash: Boolean;
+    FHashClass: TVStringHashClass;
     function GetValue(const Name: String): String;
     procedure SetValue(const Name, Value: String);
     function GetValueObject(const Name: String): TObject;
@@ -75,6 +78,7 @@ type
     property ValueObjects[const Name: String]: TObject read GetValueObject write SetValueObject;
     property OwnsObjects: Boolean read FOwnsObjects write FOwnsObjects;
     property AutoUpdateHash: Boolean read FAutoUpdateHash write FAutoUpdateHash;
+    property HashClass: TVStringHashClass read FHashClass write FHashClass;
   end;
 
 implementation
@@ -284,6 +288,7 @@ begin
   FNameHashValid := False;
   FOwnsObjects := False;
   FAutoUpdateHash := True;
+  FHashClass := TVStringHash;
 end;
 
 procedure TVHashedStringList.Delete(Index: Integer);
@@ -304,7 +309,7 @@ begin
     if bValueHashValid then
     begin
       if FValueHash = nil then
-        FValueHash := TVStringHash.Create(FBucketsSize);
+        FValueHash := FHashClass.Create(FBucketsSize);
       if not CaseSensitive then
       begin
         FValueHash.Delete(AnsiUpperCase(OldValue), Index);
@@ -318,7 +323,7 @@ begin
     if bNameHashValid then
     begin
       if FNameHash = nil then
-        FNameHash := TVStringHash.Create(FBucketsSize);
+        FNameHash := FHashClass.Create(FBucketsSize);
       P := AnsiPos(NameValueSeparator, OldValue);
       if P <> 0 then
       begin
@@ -406,7 +411,7 @@ begin
     if bValueHashValid then
     begin
       if FValueHash = nil then
-        FValueHash := TVStringHash.Create(FBucketsSize);
+        FValueHash := FHashClass.Create(FBucketsSize);
       if not CaseSensitive then
         FValueHash.Add(AnsiUpperCase(Self[Index]), Index)
       else
@@ -416,7 +421,7 @@ begin
     if bNameHashValid then
     begin
       if FNameHash = nil then
-        FNameHash := TVStringHash.Create(FBucketsSize);
+        FNameHash := FHashClass.Create(FBucketsSize);
       Key := Get(Index);
       P := AnsiPos(NameValueSeparator, Key);
       if P <> 0 then
@@ -450,7 +455,7 @@ begin
     if bValueHashValid then
     begin
       if FValueHash = nil then
-        FValueHash := TVStringHash.Create(FBucketsSize);
+        FValueHash := FHashClass.Create(FBucketsSize);
       if not CaseSensitive then
       begin
         FValueHash.Delete(AnsiUpperCase(OldValue), Index);
@@ -465,7 +470,7 @@ begin
     if bNameHashValid then
     begin
       if FNameHash = nil then
-        FNameHash := TVStringHash.Create(FBucketsSize);
+        FNameHash := FHashClass.Create(FBucketsSize);
       P := AnsiPos(NameValueSeparator, OldValue);
       if P <> 0 then
       begin
@@ -547,7 +552,7 @@ begin
   if FNameHashValid then Exit;
   
   if FNameHash = nil then
-    FNameHash := TVStringHash.Create(FBucketsSize)
+    FNameHash := FHashClass.Create(FBucketsSize)
   else
     FNameHash.Clear;
   for I := 0 to Count - 1 do
@@ -573,7 +578,7 @@ begin
   if FValueHashValid then Exit;
 
   if FValueHash = nil then
-    FValueHash := TVStringHash.Create(FBucketsSize)
+    FValueHash := FHashClass.Create(FBucketsSize)
   else
     FValueHash.Clear;
   for I := 0 to Count - 1 do
@@ -585,3 +590,4 @@ begin
 end;
 
 end.
+

--- a/src/murmurhash.pas
+++ b/src/murmurhash.pas
@@ -1,0 +1,81 @@
+unit murmurhash;
+
+interface
+
+uses  VHashedStringList;
+
+type
+  TMurMurHash = class(TVStringHash)
+  private
+    function MurmurHash2LD(Key: PChar; len, seed: Cardinal): Cardinal;
+  protected
+    function HashOf(const Key: String): Cardinal; override;
+  end;
+
+implementation
+
+function TMurMurHash.HashOf(const Key: String): Cardinal;
+begin
+  Result := MurmurHash2LD(PChar(Key), Length(Key), 0);
+end;
+
+function TMurMurHash.MurmurHash2LD(Key: PChar; len, seed: Cardinal): Cardinal;
+//--------------------------------------------------------------------
+// MurmurHash2, by Austin Appleby
+//
+// Translated from C to Delphi by Lionel Delafosse
+// Comments from Austin Appleby code
+//
+// Additional improvements taken from Patrick van Logchem
+// and Davy Landman respective implementations
+//--------------------------------------------------------------------
+const
+  // 'm' and 'r' are mixing constants generated offline.
+  // They're not really 'magic', they just happen to work well.
+  m = $5bd1e995;
+  r = 24;
+var
+  k : cardinal;
+  EndPtr : PChar;
+begin
+  // Initialize the hash to a 'random' value
+  Result := seed xor len;
+  // Mix 4 bytes at a time into the hash
+  EndPtr := Key + ((Len shr 2) shl 2);
+  while Key < EndPtr do begin
+    k := PCardinal(key)^ * m;  // k *= m;
+    k := k xor (k shr r);      // k ^= k >> r;
+    Result := Result * m;      // h *= m;
+    Result := Result xor (k * m);    // h ^= (k * m);
+    Inc(key, 4);
+  end;
+
+  if (Len and 1) <> 0
+  then begin
+    // length = 1 or 3
+    if (Len and 2) <> 0
+    then begin  // length = 3
+      Result := Result xor PWord(key)^;
+      Result := Result xor (Cardinal(PByte(key+2)^) shl 16);
+    end
+    else        // length = 1
+      Result := Result xor PByte(key)^;
+    Result := Result * m;
+  end
+  else begin  // length = 0 or 2
+    if (Len and 2) <> 0
+    then begin  // length = 2
+      Result := Result xor PWord(key)^;
+      Result := Result * m;
+    end;
+  end;
+
+  // Do a few final mixes of the hash to ensure the last few
+  // bytes are well-incorporated.
+  Result := Result xor (Result shr 13);       // h ^= h >> 13;
+  Result := Result * m;                       // h *= m;
+  Result := Result xor (Result shr 15);       // h ^= h >> 15; return h;
+end;
+
+end.
+


### PR DESCRIPTION
Несмотря на то, что метод `HashOf` класса `TVStringHash` помечен как виртуальный, мы не можем это использовать, т.к. в классе `TVHashedStringList` всегда создаются объекты типа `TVStringHash`. Добавляю новое свойство, которое позволяет указать тип создаваемого хэша. Таким образом, теперь можно в наследнике переопределить метод `HashOf` и указать, чтобы в классе `TVHashedStringList` хэши создавались типа наследника. В качестве примера добавлен MurmurHash.